### PR TITLE
Refactor DataProcessor for dependency injection

### DIFF
--- a/data_processor.py
+++ b/data_processor.py
@@ -1,14 +1,18 @@
 import pandas as pd
 import numpy as np
-from sklearn.preprocessing import StandardScaler, MinMaxScaler
+from sklearn.preprocessing import StandardScaler
 from sklearn.impute import SimpleImputer
+from typing import Optional
 import warnings
+
 warnings.filterwarnings('ignore')
 
 class DataProcessor:
-    def __init__(self):
-        self.scaler = StandardScaler()
-        self.imputer = SimpleImputer(strategy='mean')
+    def __init__(self, scaler: Optional[StandardScaler] = None,
+                 imputer: Optional[SimpleImputer] = None):
+        """Initialize the processor with optional scaler and imputer."""
+        self.scaler = scaler or StandardScaler()
+        self.imputer = imputer or SimpleImputer(strategy='mean')
         self.processed_columns = []
     
     def process_dataset(self, df, clean_missing=True, normalize=False, remove_outliers=False):

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 from data_processor import DataProcessor
+from sklearn.preprocessing import StandardScaler
 from visualization import ChartGenerator
 from utils import save_data_to_file, load_data_from_file
 import config
@@ -100,7 +101,7 @@ def display_main_content():
     # Data processing section
     st.header("Data Processing")
     
-    processor = DataProcessor()
+    processor = DataProcessor(scaler=StandardScaler())
     
     # Processing options
     col1, col2, col3 = st.columns(3)


### PR DESCRIPTION
## Summary
- allow injecting scaler and imputer into `DataProcessor`
- create scaler instance in `main` and pass it into `DataProcessor`

## Testing
- `python -m py_compile main.py data_processor.py visualization.py utils.py config.py`
- `python -c "import main; print('Import successful')"` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6862435dd3cc832688cbba1c5d2a8fa5