### PR TITLE
Replace deprecated pandas fillna method

### DIFF
--- a/data_processor.py
+++ b/data_processor.py
@@ -58,7 +58,7 @@ class DataProcessor:
         for col in datetime_cols:
             if df[col].isnull().sum() > 0:
                 # Forward fill for datetime
-                df[col].fillna(method='ffill', inplace=True)
+                df[col].ffill(inplace=True)
         
         return df
     


### PR DESCRIPTION
## Summary
- update pandas fillna usage to use `Series.ffill`

## Testing
- `python -m py_compile main.py data_processor.py visualization.py utils.py config.py`
- `python -c "import main; print('Import successful')"` *(fails: ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_6862483bc9408326b2cc061a8107aedb